### PR TITLE
Add array option to object method parameters

### DIFF
--- a/lib/Ladybug/Type/TObject.php
+++ b/lib/Ladybug/Type/TObject.php
@@ -151,6 +151,7 @@ class TObject extends TBase
                                 if($default === null) $default = 'NULL';
                                 elseif(is_bool($default)) $default = $default ? 'TRUE' : 'FALSE';
                                 elseif(is_string($default)) $default = '"' . $default . '"';
+                                elseif(is_array($default)) $default = 'Array';
                                 
                                 $parameter_result .= ' = ' . $default;
                             }


### PR DESCRIPTION
Show when parameter needs to be an array

E.G `function someFunction($name, [$options = Array])]`
