### PR TITLE
show class methods as public,static,protected,private instead of just symbols

### DIFF
--- a/lib/Ladybug/Type/TObject.php
+++ b/lib/Ladybug/Type/TObject.php
@@ -127,10 +127,11 @@ class TObject extends TBase
                         if ($method->getName() == '__toString') $this->tostring = $var->__toString();
                                 
                         $method_syntax = '';
-
-                        if ($method->isPublic()) $method_syntax .= '+ ';
-                        elseif ($method->isProtected()) $method_syntax .= '# ';
-                        elseif ($method->isPrivate()) $method_syntax .= '- ';
+                        
+                        if ($method->isStatic()) $method_syntax .= 'static ';
+                        elseif ($method->isPublic()) $method_syntax .= 'public ';
+                        elseif ($method->isProtected()) $method_syntax .= 'protected ';
+                        elseif ($method->isPrivate()) $method_syntax .= 'private ';
 
                         $method_syntax .= $method->getName();
 


### PR DESCRIPTION
When debugging a class, it is more helpful to see if a method is public,protected etc. instead of having only a +, - or # symbol.

Also added static, so you can see when a method is static
