### PR TITLE
show if a parameter should be a class

### DIFF
--- a/lib/Ladybug/Type/TObject.php
+++ b/lib/Ladybug/Type/TObject.php
@@ -139,6 +139,13 @@ class TObject extends TBase
                         $method_parameters_result = array();
                         foreach ($method_parameters as $parameter) {
                             $parameter_result = '';
+                            
+                            $class = $parameter->getClass();
+                            if($class instanceof \ReflectionClass)
+                            {
+                            	$parameter_result .= $class->getName().' ';
+                            }
+                            
                             if ($parameter->isOptional()) $parameter_result .= '[';
 
                             if ($parameter->isPassedByReference()) $parameter_result .= '&';


### PR DESCRIPTION
If a class method accepts a class as a parameter, show that class name, instead of just the parameter name

E.G `public handle(Symfony\Component\HttpFoundation\Request $request, [$type = 1], [$catch = TRUE])`
