### PR TITLE
Auto unfold the .switcher items

### DIFF
--- a/lib/Ladybug/helpers.php
+++ b/lib/Ladybug/helpers.php
@@ -33,6 +33,14 @@ function ladybug_dump_die(/*$var1 [, $var2...$varN]*/)
     die();
 }
 
+function ladybug_dump_unfold_die()
+{
+    $ladybug = \Ladybug\Dumper::getInstance();
+    echo call_user_func_array(array($ladybug,'dump'), func_get_args());
+    echo '<script>[].forEach.call(document.querySelectorAll(".switcher"),function(el){el.click();});</script>';
+    die();
+}
+
 function ladybug_dump_return(/*$format $var1 [, $var2...$varN]*/)
 {
     $ladybug = \Ladybug\Dumper::getInstance();
@@ -53,6 +61,13 @@ if (!function_exists('ldd')) {
     function ldd(/*$var1 [, $var2...$varN]*/)
     {
         echo call_user_func_array('ladybug_dump_die', func_get_args());
+    }
+}
+
+if (!function_exists('ldud')) {
+    function ldud(/*$format $var1 [, $var2...$varN]*/)
+    {
+        echo call_user_func_array('ladybug_dump_unfold_die', func_get_args());
     }
 }
 


### PR DESCRIPTION
use ladybug_dump_unfold_die or the sortcut ldud to unfold all collapsed items.

It will add a javascript that will click on .switcher dom element using document.querySelectorAll method (compatible with latest browsers)
