### PR TITLE
Issue non-success exit code on ladybug_dump_die()

### DIFF
--- a/lib/Ladybug/helpers.php
+++ b/lib/Ladybug/helpers.php
@@ -30,7 +30,7 @@ function ladybug_dump_die(/*$var1 [, $var2...$varN]*/)
 {
     $ladybug = \Ladybug\Dumper::getInstance();
     echo call_user_func_array(array($ladybug,'dump'), func_get_args());
-    die();
+    die(1);
 }
 
 function ladybug_dump_return(/*$format $var1 [, $var2...$varN]*/)


### PR DESCRIPTION
If ldd(); is called the final die() call will result in a `0` return code.

This is an issue in CI environments when someone leaves a `ldd()` in the code the build server (travis, jenkins) will issue a `Build successful` as the process exited properly.

This change would change that behavior so that calling a process with a ldd statement in it results in failure of a build (or in cli scripting cases that the script isn't considered to have run successfully).

Thank you for the lib!
