### PR TITLE
Add test for #39

### DIFF
--- a/tests/Ladybug/Tests/Type/FactoryTypeTest.php
+++ b/tests/Ladybug/Tests/Type/FactoryTypeTest.php
@@ -97,6 +97,14 @@ class FactoryTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Ladybug\\Type\\ResourceType', $type);
     }
 
+    public function testFactoryForUnknownResourceValues()
+    {
+        $var = fopen(__DIR__ . '/../../../files/test.txt', 'rb');
+        fclose($var); // Turns resource into type "Unknown"
+        $type = $this->factory->factory($var);
+        $this->assertInstanceOf('Ladybug\\Type\\ResourceType', $type);
+    }
+
     /*public function testLoaderForOtherType()
     {
         $this->setExpectedException('Ladybug\Type\Exception\InvalidVariableTypeException');


### PR DESCRIPTION
This is a test for #39 which leads to a fatal error. Closing a file handle is one of the ways to get an unknown resource.
