### PR TITLE
fix encoding problem in windows console

### DIFF
--- a/src/Ladybug/Theme/Simple/SimpleTheme.php
+++ b/src/Ladybug/Theme/Simple/SimpleTheme.php
@@ -76,7 +76,7 @@ class SimpleTheme extends AbstractTheme implements HtmlThemeInterface, CliThemeI
     public function getCliTags()
     {
         return array(
-            'tab' => '<f_tab> · </f_tab>'
+            'tab' => '<f_tab> '.chr(250).' </f_tab>'
         );
     }
 


### PR DESCRIPTION
The file was save in an UTF8 encoding and (apparently) not converted back to a codepage suitable for the windows command line (codepage 850). This patch makes sure you get the right character independent of the file encoding. Obviously detecting the environment and serving up the right codepage would be nicer, but i recommend to leave this patch in for now until there is a better solution.
