### PR TITLE
Avoid errors like Undefined variable: class

### DIFF
--- a/src/Ladybug/Type/Object/Container.php
+++ b/src/Ladybug/Type/Object/Container.php
@@ -391,6 +391,7 @@ class Container extends AbstractType
                     } catch (\ReflectionException $e) {
                         // This happens when the class method uses an undefined type hint
                         $methodParameter->setType('[Undefined Type Hint]');
+                        $class = null;
                     }
 
                     if ($class instanceof \ReflectionClass) {


### PR DESCRIPTION
Notice: Undefined variable: class
500 Internal Server Error - ContextErrorException
